### PR TITLE
feat: made the module return a function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 LUA ?= lua5.1
 LUA_PC ?= lua5.1
+LUA_LIBS ?= $(shell pkg-config $(LUA_PC) --libs)
 LUA_CFLAGS = $(shell pkg-config $(LUA_PC) --cflags)
 
 CFLAGS ?= -O3 -Wall -Werror
@@ -10,7 +11,7 @@ all: lua_uuid.so
 	$(CC) -c $(CFLAGS) -fPIC $(LUA_CFLAGS) -o $@ $<
 
 lua_uuid.so: lua_uuid.o test/lua_uuid_test.lua
-	$(CC) -shared lua_uuid.o -o $@
+	$(CC) -shared lua_uuid.o $(LUA_LIBS) -o $@
 	$(LUA) test/lua_uuid_test.lua
 
 clean:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # lua_uuid
 
-Lua library that generate UUIDs leveraging libuuid.
+Lua library that generate UUIDs leveraging [libuuid](http://linux.die.net/man/3/libuuid).
 
 ## Usage
 
-To generate an unique UUID string:
+To generate a new UUID string:
 
 ```lua
-local lua_uuid = require "lua_uuid"
-local uuid_str = lua_uuid.generate()
+local uuid = require "lua_uuid"
+local uuid_str = uuid()
 
-print("The UUID is "..uuid_str)
+print("New UUID: "..uuid_str)
 ```

--- a/lua_uuid.c
+++ b/lua_uuid.c
@@ -1,42 +1,28 @@
 /***
-Utility for generating UUIDs
+Utility for generating UUIDs by wrapping libuuid's generate().
 
 @license MIT
 @module lua_uuid
 */
-#define LUA_LIB
 #include <lua.h>
 #include <lauxlib.h>
 #include <uuid/uuid.h>
 
-#if LUA_VERSION_NUM < 502
-# define luaL_newlib(L,l) (lua_newtable(L), luaL_register(L,NULL,l))
-# define lua_rawlen lua_objlen
-#endif
-
-/// Generate an UUID
+/// Generate a UUID
 // @return uuid_str
 // @function generate()
 static int generate(lua_State *L) {
-
-    // Generate UUID
     uuid_t uuid;
-    uuid_generate(uuid);
+    char uuid_str[37];
 
-    // Unparse to a string
-    char uuid_str[37]; // For example: "1b4e28ba-2fa1-11d2-883f-0016d3cca427" + "\0"
+    uuid_generate(uuid);
     uuid_unparse_lower(uuid, uuid_str);
 
     lua_pushstring(L, uuid_str);
     return 1;
 }
 
-static const luaL_Reg lua_uuid[] = {
-    {"generate", generate},
-    {NULL, NULL}
-};
-
-int luaopen_lua_uuid(lua_State *L){
-    luaL_newlib(L, lua_uuid);
+int luaopen_lua_uuid(lua_State *L) {
+    lua_pushcfunction(L, generate);
     return 1;
 }

--- a/test/lua_uuid_test.lua
+++ b/test/lua_uuid_test.lua
@@ -1,8 +1,11 @@
-local lua_uuid = require "lua_uuid"
+package.path = package.path..";./?.lua"
 
-assert(lua_uuid.generate())
+local uuid = require "lua_uuid"
 
-local first = lua_uuid.generate()
-local second = lua_uuid.generate()
+assert(type(uuid) == "function")
+
+local first = uuid()
+local second = uuid()
 
 assert(first ~= second)
+assert(type(uuid()) == "string")


### PR DESCRIPTION
- also add lua lib path to the .so creation to ensure compilation
  (generally lua header files are not in the standard compiler's search
  paths)
- remove boilerplate
- the bare minium tests addition

This allows to execute:

``` lua
local uuid = require "lua_uuid"
uuid()
```
