### PR TITLE
Use luarocks backend to build

### DIFF
--- a/lua_uuid-0.1-8.rockspec
+++ b/lua_uuid-0.1-8.rockspec
@@ -16,15 +16,11 @@ dependencies = {
   "lua >= 5.1"
 }
 build = {
-  type = "make",
-  build_variables = {
-    LUA="$(LUA)",
-    CFLAGS="$(CFLAGS)",
-    LIBFLAG="$(LIBFLAG)",
-    LUA_LIBDIR="-L$(LUA_LIBDIR)",
-    LUA_INCDIR="-I$(LUA_INCDIR)"
-  },
-  install_variables = {
-    INST_LIBDIR = "$(LIBDIR)"
+  type = "builtin",
+  modules = {
+    ["lua_uuid"] = {
+      sources = { "lua_uuid.c" },
+      libraries = { "uuid" },
+    },  
   }
 }


### PR DESCRIPTION
Updated to use the luarocks build-backend when installing through LuaRocks. Instead of external make file and build dependencies.
Also allows for removal, which the make file does not support (through LuaRocks) iirc.

(it forced me to install additional dependencies on a blank system)
