### PR TITLE
lua5.1 rename to lua

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LUA ?= lua5.1
+LUA ?= lua
 LUA_LIBDIR ?= $(shell pkg-config $(LUA) --libs)
 LUA_INCDIR ?= $(shell pkg-config $(LUA) --cflags)
 


### PR DESCRIPTION
default, centos is no lua5.1,  I think use `lua` is better 

_OS_: CentOS Linux release 7.2.1511 (Core)
